### PR TITLE
Updated incorrect word in documentation

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/QuickStartGuide.md
+++ b/Packages/com.unity.inputsystem/Documentation~/QuickStartGuide.md
@@ -36,7 +36,7 @@ The same approach works for other Devices types (for example, [`Keyboard.current
 
 ## Getting input indirectly through an Input Action
 
-To get input directly through an Input Action, follow these steps, which are explained in detail below:
+To get input indirectly through an Input Action, follow these steps, which are explained in detail below:
 
 1. Add a `PlayerInput` component.
 2. Create Actions.


### PR DESCRIPTION
The word "directly" was mistakenly used instead of "indirectly". I fixed that so it now matches the header above it.